### PR TITLE
Support custom certificates

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -85,7 +85,6 @@ in
       {
         pname = (metadata.name);
         version = metadata.version;
-        impureEnvVars = [ "NIX_SSL_CERT_FILE" ];
         nativeBuildInputs = mergedNativeBuildInputs;
 
         buildPhase = ''


### PR DESCRIPTION
Adds `impureEnvVars` to allow the `NIX_SSL_CERT_FILE` to be passed down to the setup script for `cacerts`. Fixes an issue I was having where I couldn't build apps on work laptop