### PR TITLE
Stable paths in `nimble.paths`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,6 @@ jobs:
 
       - name: Test a dev environment can be used
         working-directory: testProjects/testProject
-        run: nix develop -c nim r src/testProject.nim
+        run: |
+          nix develop -c nim r src/testProject.nim
+          nix develop -c nimble test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,5 @@ jobs:
         working-directory: testProjects/testProject
         run: |
           nix develop -c nim r src/testProject.nim
-          nix develop -c nimble test
+          # I don't recommend using nimble...
+          # nix develop -c nimble test

--- a/default.nix
+++ b/default.nix
@@ -109,7 +109,7 @@ in
           # Create symlink to dependencies in the store
           ln -s ${deps}/pkgs2 nimbledeps/pkgs2
 
-          # TODO: Add gcroot so paths don't get deleted
+          # TODO: Add gcroot so paths don't get deleted?
 
           # Make sure nimble.paths points to our deps
           nimble setup --useSystemNim --solver:legacy setup --offline

--- a/default.nix
+++ b/default.nix
@@ -103,19 +103,19 @@ in
         nativeBuildInputs = mergedNativeBuildInputs;
         shellHook = ''
           # Create the local folder to make Nimble use local dependencies
-          rm -rf $(pwd)/.nimbledeps
-          mkdir -p $(pwd)/.nimbledeps
+          rm -rf $(pwd)/nimbledeps
+          mkdir -p $(pwd)/nimbledeps
 
           # Nimble likes to write to files in it
           chmod -R +w .nimbledeps
 
           # Create symlink to dependencies in the store
-          ln -s ${deps}/pkgs2 .nimbledeps/pkgs2
+          ln -s ${deps}/pkgs2 nimbledeps/pkgs2
 
           # TODO: Add gcroot so paths don't get deleted
 
           # Make sure nimble.paths points to our deps
-          nimble -l setup --offline
+          nimble setup --offline
         '';
         buildPhase = ''
           runHook preBuild

--- a/default.nix
+++ b/default.nix
@@ -29,6 +29,9 @@ let
         # are no locked dependencies
         nimble --useSystemNim --solver:legacy setup
 
+        # Update the file so we have a variable we can easily replace later
+        sed -i "s^$(pwd)^PROJECT_PATH^g" nimble.paths
+
         # Sometimes the files listed in each nimblemeta.json file is in a different order.
         # We'll sort that so the hash is consistent
         for file in $(find -name nimblemeta.json); do
@@ -38,7 +41,9 @@ let
       '';
 
       installPhase = ''
-        cp -r nimbledeps $out
+        mkdir -p $out
+        cp -r nimbledeps $out/deps
+        cp nimble.paths $out/nimble.paths
       '';
 
       outputHashAlgo = "sha256";
@@ -88,7 +93,7 @@ in
       setupNimbleDir = ''
         # Copy into a temp directory we can write to. Nimble likes to update the nimbledata2.json file
         export NIMBLE_DIR=$(mktemp -d)
-        cp -r ${deps}/* $NIMBLE_DIR
+        cp -r ${deps}/deps/* $NIMBLE_DIR
         chmod +w $NIMBLE_DIR/nimbledata2.json
 
         # Create empty files to stop nimble from trying to download them
@@ -102,14 +107,25 @@ in
         version = metadata.version;
         nativeBuildInputs = mergedNativeBuildInputs;
         shellHook = ''
-          # Create the local folder to make Nimble use local dependencies
-          mkdir -p $(pwd)/nimbledeps
+          # Check if nimbledeps needs to be set up
+          NEED_SETUP=0
 
-          # Create symlink to dependencies in the store
-          ln -sf ${deps}/pkgs2 nimbledeps/pkgs2
+          if [ ! -L nimbledeps/pkgs2 ]; then
+            NEED_SETUP=1
+          elif [ "$(readlink nimbledeps/pkgs2)" != "${deps}/deps/pkgs2" ]; then
+            NEED_SETUP=1
+          fi
 
-          # Make sure nimble.paths points to our deps
-          nimble setup --useSystemNim --solver:legacy setup --offline
+          if [ "$NEED_SETUP" -eq 1 ]; then
+            # Create the local folder to make Nimble use local dependencies
+            mkdir -p nimbledeps
+
+            # Create symlink to dependencies in the store
+            ln -sf ${deps}/deps/pkgs2 nimbledeps/pkgs2
+
+            # Copy nimble.paths from deps and replace PROJECT_PATH with actual path
+            sed "s^PROJECT_PATH^$(pwd)^g" ${deps}/nimble.paths > nimble.paths
+          fi
         '';
         buildPhase = ''
           runHook preBuild

--- a/default.nix
+++ b/default.nix
@@ -108,7 +108,7 @@ in
           # Either we haven't linked the pacakges or the folder is missing
           if [ ! -L nimbledeps/pkgs2 ]; then
             NEED_SETUP=1
-          elif [ "$(readlink nimbledeps/pkgs2)" != "${deps}/deps/pkgs2" ]; then
+          elif [ "$(readlink nimbledeps/pkgs2)" != "${deps}/pkgs2" ]; then
             NEED_SETUP=1
           fi
 

--- a/default.nix
+++ b/default.nix
@@ -103,11 +103,10 @@ in
         nativeBuildInputs = mergedNativeBuildInputs;
         shellHook = ''
           # Create the local folder to make Nimble use local dependencies
-          rm -rf $(pwd)/nimbledeps
           mkdir -p $(pwd)/nimbledeps
 
           # Create symlink to dependencies in the store
-          ln -s ${deps}/pkgs2 nimbledeps/pkgs2
+          ln -sf ${deps}/pkgs2 nimbledeps/pkgs2
 
           # Make sure nimble.paths points to our deps
           nimble setup --useSystemNim --solver:legacy setup --offline

--- a/default.nix
+++ b/default.nix
@@ -109,8 +109,6 @@ in
           # Create symlink to dependencies in the store
           ln -s ${deps}/pkgs2 nimbledeps/pkgs2
 
-          # TODO: Add gcroot so paths don't get deleted?
-
           # Make sure nimble.paths points to our deps
           nimble setup --useSystemNim --solver:legacy setup --offline
         '';

--- a/default.nix
+++ b/default.nix
@@ -29,9 +29,6 @@ let
         # are no locked dependencies
         nimble --useSystemNim --solver:legacy setup
 
-        # Update the file so we have a variable we can easily replace later
-        sed -i "s^$(pwd)^PROJECT_PATH^g" nimble.paths
-
         # Sometimes the files listed in each nimblemeta.json file is in a different order.
         # We'll sort that so the hash is consistent
         for file in $(find -name nimblemeta.json); do
@@ -41,9 +38,7 @@ let
       '';
 
       installPhase = ''
-        mkdir -p $out
-        cp -r nimbledeps $out/deps
-        cp nimble.paths $out/nimble.paths
+        cp -r nimbledeps $out
       '';
 
       outputHashAlgo = "sha256";
@@ -93,7 +88,7 @@ in
       setupNimbleDir = ''
         # Copy into a temp directory we can write to. Nimble likes to update the nimbledata2.json file
         export NIMBLE_DIR=$(mktemp -d)
-        cp -r ${deps}/deps/* $NIMBLE_DIR
+        cp -r ${deps}/* $NIMBLE_DIR
         chmod +w $NIMBLE_DIR/nimbledata2.json
 
         # Create empty files to stop nimble from trying to download them
@@ -107,9 +102,10 @@ in
         version = metadata.version;
         nativeBuildInputs = mergedNativeBuildInputs;
         shellHook = ''
-          # Check if nimbledeps needs to be set up
           NEED_SETUP=0
 
+          # Check if nimbledeps needs to be set up
+          # Either we haven't linked the pacakges or the folder is missing
           if [ ! -L nimbledeps/pkgs2 ]; then
             NEED_SETUP=1
           elif [ "$(readlink nimbledeps/pkgs2)" != "${deps}/deps/pkgs2" ]; then
@@ -120,11 +116,21 @@ in
             # Create the local folder to make Nimble use local dependencies
             mkdir -p nimbledeps
 
-            # Create symlink to dependencies in the store
-            ln -sf ${deps}/deps/pkgs2 nimbledeps/pkgs2
+            # Create empty files to stop nimble from trying to download them
+            echo "[]" > nimbledeps/packages_official.json
+            echo "[]" > nimbledeps/official-nim-releases.json
 
-            # Copy nimble.paths from deps and replace PROJECT_PATH with actual path
-            sed "s^PROJECT_PATH^$(pwd)^g" ${deps}/nimble.paths > nimble.paths
+            # Create symlink to dependencies in the store
+            ln -sf ${deps}/pkgs2 nimbledeps/pkgs2
+
+            # Generate nimble.paths from what's actually in the store
+            {
+              echo "--noNimblePath"
+              # Add each pkg as a path
+              find -L $(pwd)/nimbledeps/pkgs2/ -maxdepth 1 -type d | tail -n +2 | while read dir; do
+                echo "--path:\"$dir\""
+              done
+            } > nimble.paths
           fi
         '';
         buildPhase = ''

--- a/default.nix
+++ b/default.nix
@@ -102,13 +102,17 @@ in
         version = metadata.version;
         nativeBuildInputs = mergedNativeBuildInputs;
         shellHook = ''
-          # Create the local deps and copy everything into it
+          # Create the local folder to make Nimble use local dependencies
           rm -rf $(pwd)/.nimbledeps
           mkdir -p $(pwd)/.nimbledeps
-          cp -r ${deps}/* $(pwd)/.nimbledeps/
 
           # Nimble likes to write to files in it
           chmod -R +w .nimbledeps
+
+          # Create symlink to dependencies in the store
+          ln -s ${deps}/pkgs2 .nimbledeps/pkgs2
+
+          # TODO: Add gcroot so paths don't get deleted
 
           # Make sure nimble.paths points to our deps
           nimble -l setup --offline

--- a/default.nix
+++ b/default.nix
@@ -102,12 +102,16 @@ in
         version = metadata.version;
         nativeBuildInputs = mergedNativeBuildInputs;
         shellHook = ''
-          ${setupNimbleDir}
-          # Allow us to delete the dev shell when finished
-          chmod +w -R $NIMBLE_DIR
+          # Create the local deps and copy everything into it
+          rm -rf $(pwd)/.nimbledeps
+          mkdir -p $(pwd)/.nimbledeps
+          cp -r ${deps}/* $(pwd)/.nimbledeps/
+
+          # Nimble likes to write to files in it
+          chmod -R +w .nimbledeps
 
           # Make sure nimble.paths points to our deps
-          nimble setup
+          nimble -l setup --offline
         '';
         buildPhase = ''
           runHook preBuild

--- a/default.nix
+++ b/default.nix
@@ -27,7 +27,7 @@ let
         # Run setup to pull all the dependencies. The solver is set to legacy to get around a bug
         # where nimble tries to install Nim when there are no dependencies since it thinks there
         # are no locked dependencies
-        nimble --useSystemNim --solver:legacy --debug setup
+        nimble --useSystemNim --solver:legacy setup
 
         # Sometimes the files listed in each nimblemeta.json file is in a different order.
         # We'll sort that so the hash is consistent
@@ -106,16 +106,13 @@ in
           rm -rf $(pwd)/nimbledeps
           mkdir -p $(pwd)/nimbledeps
 
-          # Nimble likes to write to files in it
-          chmod -R +w .nimbledeps
-
           # Create symlink to dependencies in the store
           ln -s ${deps}/pkgs2 nimbledeps/pkgs2
 
           # TODO: Add gcroot so paths don't get deleted
 
           # Make sure nimble.paths points to our deps
-          nimble setup --offline
+          nimble setup --useSystemNim --solver:legacy setup --offline
         '';
         buildPhase = ''
           runHook preBuild

--- a/testProjects/testProject/flake.lock
+++ b/testProjects/testProject/flake.lock
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "path": "../",
+        "path": "../../",
         "type": "path"
       },
       "original": {
-        "path": "../",
+        "path": "../../",
         "type": "path"
       },
       "parent": []

--- a/testProjects/testProject/flake.nix
+++ b/testProjects/testProject/flake.nix
@@ -24,7 +24,7 @@
       {
         packages.default = mkNimbleApp {
           src = ./.;
-          nimbleHash = "sha256-9meBcyeRgceZlZnipacFke+41ZKw7jh94JxqoaUGmXE=";
+          nimbleHash = "";
         };
       }
     );

--- a/testProjects/testProject/flake.nix
+++ b/testProjects/testProject/flake.nix
@@ -24,7 +24,7 @@
       {
         packages.default = mkNimbleApp {
           src = ./.;
-          nimbleHash = "";
+          nimbleHash = "sha256-LZ1qmUvO931RMQMwb4LyofO6Vot4jND/Ug2+D8gsQBk=";
         };
       }
     );

--- a/testProjects/testProject/flake.nix
+++ b/testProjects/testProject/flake.nix
@@ -24,7 +24,7 @@
       {
         packages.default = mkNimbleApp {
           src = ./.;
-          nimbleHash = "sha256-LZ1qmUvO931RMQMwb4LyofO6Vot4jND/Ug2+D8gsQBk=";
+          nimbleHash = "sha256-eOcf2v4gwCgFWStkA4RnORlEkZh8ydg1Y3Fg3qbzzwM=";
         };
       }
     );

--- a/testProjects/testProject/flake.nix
+++ b/testProjects/testProject/flake.nix
@@ -24,7 +24,7 @@
       {
         packages.default = mkNimbleApp {
           src = ./.;
-          nimbleHash = "sha256-eOcf2v4gwCgFWStkA4RnORlEkZh8ydg1Y3Fg3qbzzwM=";
+          nimbleHash = "sha256-LZ1qmUvO931RMQMwb4LyofO6Vot4jND/Ug2+D8gsQBk=";
         };
       }
     );

--- a/testProjects/testProject/nimble.lock
+++ b/testProjects/testProject/nimble.lock
@@ -10,6 +10,76 @@
       "checksums": {
         "sha1": "bc5242cbfd4feb63779f33d6d433d0a65b7dca75"
       }
+    },
+    "threading": {
+      "version": "0.2.1",
+      "vcsRevision": "c5a39a039f24d48ba9503dcb9a0aee68a0fbb36d",
+      "url": "https://github.com/nim-lang/threading",
+      "downloadMethod": "git",
+      "dependencies": [],
+      "checksums": {
+        "sha1": "6904743cf079e9715f15a1e9e84c8187113ce1f4"
+      }
+    },
+    "jaysonrpc": {
+      "version": "0.1.0",
+      "vcsRevision": "0f1f4fc64f8824e413a7757128397de0a60b9c73",
+      "url": "https://github.com/ire4ever1190/jaysonrpc",
+      "downloadMethod": "git",
+      "dependencies": [
+        "threading"
+      ],
+      "checksums": {
+        "sha1": "45db237c56ca92423b167a645d8e056728381eae"
+      }
+    },
+    "results": {
+      "version": "0.5.1",
+      "vcsRevision": "df8113dda4c2d74d460a8fa98252b0b771bf1f27",
+      "url": "https://github.com/arnetheduck/nim-results",
+      "downloadMethod": "git",
+      "dependencies": [],
+      "checksums": {
+        "sha1": "a9c011f74bc9ed5c91103917b9f382b12e82a9e7"
+      }
+    },
+    "unittest2": {
+      "version": "0.2.5",
+      "vcsRevision": "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189",
+      "url": "https://github.com/status-im/nim-unittest2",
+      "downloadMethod": "git",
+      "dependencies": [],
+      "checksums": {
+        "sha1": "02bb3751ba9ddc3c17bfd89f2e41cb6bfb8fc0c9"
+      }
+    },
+    "minilru": {
+      "version": "0.1.0",
+      "vcsRevision": "c35304151ea39077330f225e3837450990d55e48",
+      "url": "https://github.com/status-im/nim-minilru",
+      "downloadMethod": "git",
+      "dependencies": [
+        "results",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "9f200310ac8455e07e6d3a9d1b4088677cb63603"
+      }
+    },
+    "nimsight": {
+      "version": "0.2.0",
+      "vcsRevision": "857a3da8227857caa35173b96e6e4f56620db1e2",
+      "url": "https://github.com/ire4ever1190/nimsight",
+      "downloadMethod": "git",
+      "dependencies": [
+        "anano",
+        "threading",
+        "minilru",
+        "jaysonrpc"
+      ],
+      "checksums": {
+        "sha1": "fede2df3068dbe2e5d997e4f8f92209cd53775ca"
+      }
     }
   },
   "tasks": {}

--- a/testProjects/testProject/nimble.lock
+++ b/testProjects/testProject/nimble.lock
@@ -1,84 +1,38 @@
 {
   "version": 2,
   "packages": {
+    "nim": {
+      "version": "2.3.1",
+      "vcsRevision": "",
+      "url": "https://github.com/nim-lang/Nim.git",
+      "downloadMethod": "git",
+      "dependencies": [],
+      "checksums": {
+        "sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+      }
+    },
     "anano": {
       "version": "0.2.1",
       "vcsRevision": "2534c8fc60f463fd7f9573ce235c0c07f632af45",
       "url": "https://github.com/ire4ever1190/anano",
       "downloadMethod": "git",
-      "dependencies": [],
+      "dependencies": [
+        "nim"
+      ],
       "checksums": {
         "sha1": "bc5242cbfd4feb63779f33d6d433d0a65b7dca75"
       }
     },
-    "threading": {
-      "version": "0.2.1",
-      "vcsRevision": "c5a39a039f24d48ba9503dcb9a0aee68a0fbb36d",
-      "url": "https://github.com/nim-lang/threading",
-      "downloadMethod": "git",
-      "dependencies": [],
-      "checksums": {
-        "sha1": "6904743cf079e9715f15a1e9e84c8187113ce1f4"
-      }
-    },
-    "jaysonrpc": {
-      "version": "0.1.0",
-      "vcsRevision": "0f1f4fc64f8824e413a7757128397de0a60b9c73",
-      "url": "https://github.com/ire4ever1190/jaysonrpc",
+    "nort": {
+      "version": "0.3.0",
+      "vcsRevision": "f2882def9eb8e0d125ef82020d45921b98b44025",
+      "url": "https://github.com/ire4ever1190/nort",
       "downloadMethod": "git",
       "dependencies": [
-        "threading"
+        "nim"
       ],
       "checksums": {
-        "sha1": "45db237c56ca92423b167a645d8e056728381eae"
-      }
-    },
-    "results": {
-      "version": "0.5.1",
-      "vcsRevision": "df8113dda4c2d74d460a8fa98252b0b771bf1f27",
-      "url": "https://github.com/arnetheduck/nim-results",
-      "downloadMethod": "git",
-      "dependencies": [],
-      "checksums": {
-        "sha1": "a9c011f74bc9ed5c91103917b9f382b12e82a9e7"
-      }
-    },
-    "unittest2": {
-      "version": "0.2.5",
-      "vcsRevision": "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189",
-      "url": "https://github.com/status-im/nim-unittest2",
-      "downloadMethod": "git",
-      "dependencies": [],
-      "checksums": {
-        "sha1": "02bb3751ba9ddc3c17bfd89f2e41cb6bfb8fc0c9"
-      }
-    },
-    "minilru": {
-      "version": "0.1.0",
-      "vcsRevision": "c35304151ea39077330f225e3837450990d55e48",
-      "url": "https://github.com/status-im/nim-minilru",
-      "downloadMethod": "git",
-      "dependencies": [
-        "results",
-        "unittest2"
-      ],
-      "checksums": {
-        "sha1": "9f200310ac8455e07e6d3a9d1b4088677cb63603"
-      }
-    },
-    "nimsight": {
-      "version": "0.2.0",
-      "vcsRevision": "857a3da8227857caa35173b96e6e4f56620db1e2",
-      "url": "https://github.com/ire4ever1190/nimsight",
-      "downloadMethod": "git",
-      "dependencies": [
-        "anano",
-        "threading",
-        "minilru",
-        "jaysonrpc"
-      ],
-      "checksums": {
-        "sha1": "fede2df3068dbe2e5d997e4f8f92209cd53775ca"
+        "sha1": "f527077055e1d6c56ad17480c64dac7ad7cdce0b"
       }
     }
   },

--- a/testProjects/testProject/testProject.nimble
+++ b/testProjects/testProject/testProject.nimble
@@ -12,3 +12,4 @@ bin           = @["testProject"]
 
 requires "nim >= 2.2.6"
 requires "anano"
+requires "gh:ire4ever1190/nimsight"

--- a/testProjects/testProject/testProject.nimble
+++ b/testProjects/testProject/testProject.nimble
@@ -12,4 +12,4 @@ bin           = @["testProject"]
 
 requires "nim >= 2.2.6"
 requires "anano"
-requires "gh:ire4ever1190/nimsight"
+requires "gh:ire4ever1190/nort"

--- a/testProjects/testProject/tests/testApp.nim
+++ b/testProjects/testProject/tests/testApp.nim
@@ -1,1 +1,3 @@
+import pkg/nort
+
 echo "Tests passing"


### PR DESCRIPTION
Noticed when I opened up two dev shells that Nim would start failing to find dependencies. Looked to be due to the `nimble.paths` file pointing to things that didn't exist.

This uses local dependencies so the paths are constant. Also now symlinks the deps so files don't need to get copied around and generates the nimble.paths file manually to reduce time to shell