### PR TITLE
Fix tests failing

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -113,8 +113,9 @@ in
           runHook preBuild
 
           ${setupNimbleDir}
+          export NIMBLE_ARGS="--useSystemNim --nim:${pkgs.nim}/bin/nim --nimcache:$(mktemp -d)"
 
-          nimble --useSystemNim --nim:${pkgs.nim}/bin/nim --nimcache:$(mktemp -d) --offline -d:release build
+          nimble $NIMBLE_ARGS --offline -d:release build
 
           runHook postBuild
         '';
@@ -123,7 +124,7 @@ in
         checkPhase = ''
           runHook preCheck
 
-          nimble --useSystemNim --nim:${pkgs.nim}/bin/nim --offline test
+          nimble $NIMBLE_ARGS --offline test
 
           runHook postCheck
         '';

--- a/testProjects/testProject/flake.lock
+++ b/testProjects/testProject/flake.lock
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "path": "../",
+        "path": "../../",
         "type": "path"
       },
       "original": {
-        "path": "../",
+        "path": "../../",
         "type": "path"
       },
       "parent": []

--- a/testProjects/testProject/tests/testApp.nim
+++ b/testProjects/testProject/tests/testApp.nim
@@ -1,0 +1,1 @@
+echo "Tests passing"


### PR DESCRIPTION
Tests were running into an issue that they couldn't write to the cache. This fixes it by using a cache just like the binary build does