### PR TITLE
Dont fixup files

### DIFF
--- a/nix/buildAtlasApp.nix
+++ b/nix/buildAtlasApp.nix
@@ -34,6 +34,7 @@ let
         cp nim.cfg $out/nim.cfg
       '';
 
+      dontFixup = true;
       outputHashAlgo = "sha256";
       outputHashMode = "recursive";
       outputHash = hash;


### PR DESCRIPTION
Shebang in a test script for jamp was getting patched and causing Nix to error about FOD pointing to a store path